### PR TITLE
Changing target framework in Dazinator.Extensions.Options.Updatable project from netcoreapp3.0 to netstandard2.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 skip_tags: true
-image: Visual Studio 2019 Preview
+image: Visual Studio 2019
 
 install:
   - cmd: choco install gitversion.portable --version 4.0.0 -y

--- a/src/Dazinator.Extensions.Options.Updatable.Tests/Dazinator.Extensions.Options.Updatable.Tests.csproj
+++ b/src/Dazinator.Extensions.Options.Updatable.Tests/Dazinator.Extensions.Options.Updatable.Tests.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Dazinator.AspNet.Extensions.FileProviders" Version="1.5.0-unstable0014" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.1.0">
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -24,6 +24,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Dazinator.Extensions.Options.Updatable\Dazinator.Extensions.Options.Updatable.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Dazinator.Extensions.Options.Updatable/Dazinator.Extensions.Options.Updatable.csproj
+++ b/src/Dazinator.Extensions.Options.Updatable/Dazinator.Extensions.Options.Updatable.csproj
@@ -16,4 +16,11 @@
     <ProjectReference Include="..\Dazinator.Extensions.Options\Dazinator.Extensions.Options.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/src/Dazinator.Extensions.Options.Updatable/Dazinator.Extensions.Options.Updatable.csproj
+++ b/src/Dazinator.Extensions.Options.Updatable/Dazinator.Extensions.Options.Updatable.csproj
@@ -1,16 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0-preview7.19362.4" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="3.0.0-preview7.19362.4" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0-preview7.19362.4" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0-preview7.19362.4" />
-    <PackageReference Include="System.Text.Json" Version="4.7.0" />
-    <!--<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />-->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dazinator.Extensions.Options.sln
+++ b/src/Dazinator.Extensions.Options.sln
@@ -12,11 +12,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dazinator.Extensions.Options.Updatable", "Dazinator.Extensions.Options.Updatable\Dazinator.Extensions.Options.Updatable.csproj", "{6BB8D5C3-2C99-43E9-97F8-1DCB5027BD92}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dazinator.Extensions.Options.Updatable.Tests", "Dazinator.Extensions.Options.Updatable.Tests\Dazinator.Extensions.Options.Updatable.Tests.csproj", "{15C5D2C4-A3DD-49F1-A41B-4249FC1DE03F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dazinator.Extensions.Options", "Dazinator.Extensions.Options\Dazinator.Extensions.Options.csproj", "{F58D0DAE-6B6D-4F60-B11D-B67B66C50FE9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dazinator.Extensions.Options.Updatable", "Dazinator.Extensions.Options.Updatable\Dazinator.Extensions.Options.Updatable.csproj", "{9893E8D0-08D4-4CE2-B056-BE3AEB875DE2}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F58D0DAE-6B6D-4F60-B11D-B67B66C50FE9} = {F58D0DAE-6B6D-4F60-B11D-B67B66C50FE9}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,10 +27,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6BB8D5C3-2C99-43E9-97F8-1DCB5027BD92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6BB8D5C3-2C99-43E9-97F8-1DCB5027BD92}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6BB8D5C3-2C99-43E9-97F8-1DCB5027BD92}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6BB8D5C3-2C99-43E9-97F8-1DCB5027BD92}.Release|Any CPU.Build.0 = Release|Any CPU
 		{15C5D2C4-A3DD-49F1-A41B-4249FC1DE03F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{15C5D2C4-A3DD-49F1-A41B-4249FC1DE03F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{15C5D2C4-A3DD-49F1-A41B-4249FC1DE03F}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -36,6 +35,10 @@ Global
 		{F58D0DAE-6B6D-4F60-B11D-B67B66C50FE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F58D0DAE-6B6D-4F60-B11D-B67B66C50FE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F58D0DAE-6B6D-4F60-B11D-B67B66C50FE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9893E8D0-08D4-4CE2-B056-BE3AEB875DE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9893E8D0-08D4-4CE2-B056-BE3AEB875DE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9893E8D0-08D4-4CE2-B056-BE3AEB875DE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9893E8D0-08D4-4CE2-B056-BE3AEB875DE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Dazinator.Extensions.Options/Dazinator.Extensions.Options.csproj
+++ b/src/Dazinator.Extensions.Options/Dazinator.Extensions.Options.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Dazinator.Extensions.Options/Dazinator.Extensions.Options.csproj
+++ b/src/Dazinator.Extensions.Options/Dazinator.Extensions.Options.csproj
@@ -1,11 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi,
I have one legacy project in .NET framework. I would like use your very useful lib, but I cannot because of target framework. I also changed some preview dependencies to current version. So I hope that changes will possible. Thx